### PR TITLE
Attempt to implement functions with Types as Tables

### DIFF
--- a/experiments/Schema/src/Query.jl
+++ b/experiments/Schema/src/Query.jl
@@ -150,6 +150,8 @@ module QueryLib
 
     id(A::Types) = begin
 
+      # Define unique names so that the domain and codomain of id don't
+      # interfere
       unique_names = uniquify(vcat(A.uid_names, A.uid_names))
       dom_names = unique_names[1:length(A.uid_names)]
       codom_names = unique_names[(length(A.uid_names)+1):end]
@@ -162,6 +164,7 @@ module QueryLib
     end
 
     braid(A::Types, B::Types) = begin
+      # Use id and swap the A and B fields
       id_ab = id(otimes(A,B))
       Query(otimes(A,B),otimes(B,A),
             id_ab.dom_names,
@@ -171,6 +174,8 @@ module QueryLib
     end
 
     mcopy(A::Types) = begin
+      # Create with 3 equivalent columns of type A and split them to domain and
+      # range
       dom = A
       codom = otimes(A,A)
 
@@ -193,14 +198,6 @@ module QueryLib
       dagger(create(A))
     end
 
-    encode(A::Types) = begin
-      Query(Types(fill("text",length(A.types))), A, A.val_names, A.uid_names, A.type_query)
-    end
-
-    decode(A::Types) = begin
-      dagger(encode(A))
-    end
-
     dunit(A::Types) = begin
       compose(create(A), mcopy(A))
     end
@@ -211,6 +208,15 @@ module QueryLib
 
     top(A::Types, B::Types) = begin
       compose(delete(A),create(B))
+    end
+
+    # Encode and decode are helper functions to retrieve actual values
+    encode(A::Types) = begin
+      Query(Types(fill("text",length(A.types))), A, A.val_names, A.uid_names, A.type_query)
+    end
+
+    decode(A::Types) = begin
+      dagger(encode(A))
     end
   end
 

--- a/experiments/Schema/src/Testing.jl
+++ b/experiments/Schema/src/Testing.jl
@@ -1,24 +1,25 @@
 # here is an example
-using Catlab, Catlab.Doctrines, Catlab.Present 
+using Catlab, Catlab.Doctrines, Catlab.Present
 using Schema.QueryLib, Schema.Presentation
 import Schema.Presentation: Schema, sql
 
 # Define the Types
-Name = Ob(FreeBicategoryRelationsMeet, (:full_name, (first=String, last=String)))
-Person = Ob(FreeBicategoryRelationsMeet, (:person, (id=Int,)))
-X = Ob(FreeBicategoryRelationsMeet, Int)
-F = Ob(FreeBicategoryRelationsMeet, Float64)
-ID = Ob(FreeBicategoryRelationsMeet, (:ID, (id=Int,)))
+Name = Ob(FreeBicategoryRelations, (:full_name, (first=String, last=String)))
+Person = Ob(FreeBicategoryRelations, (:person, (id=Int,)))
+X = Ob(FreeBicategoryRelations, Int)
+F = Ob(FreeBicategoryRelations, Float64)
+ID = Ob(FreeBicategoryRelations, (:ID, (id=Int,)))
 
 # Define the relationships
 names = Hom((name=:names, fields=("person", "full_name")), Person, Name)
-emply = Hom((name=:employees, fields=("person", "ID")), Person, ID)
+employees = Hom((name=:employees, fields=("person", "ID")), Person, ID)
+customers = Hom((name=:customers, fields=("customers", "ID")), Person, ID)
 manag = Hom((name=:manager, fields=("person", "manager")), Person, Person)
 salry = Hom((name=:salary, fields=("person", "salary")), Person, F)
 
 # Set up arrays of types and relationships for Schema
 types = [Name, Person, X,F,ID]
-rels = [names, emply, manag, salry]
+rels = [names, employees, customers, manag, salry]
 
 # Generate the Schema
 prim, tab = sql(Schema(types, rels))
@@ -26,5 +27,5 @@ prim, tab = sql(Schema(types, rels))
 @show tab
 
 # Generate and display a query to get (names, salaries)
-formula = dagger(names)⋅salry
+formula = create(Person)⋅employees #dunit(Person)⋅(employees⊗customers)⋅mmerge(ID)
 println(make_query(Schema(types, rels), formula))

--- a/experiments/Schema/src/Testing.jl
+++ b/experiments/Schema/src/Testing.jl
@@ -23,9 +23,12 @@ rels = [names, employees, customers, manag, salry]
 
 # Generate the Schema
 prim, tab = sql(Schema(types, rels))
-@show prim
-@show tab
+println("Copy the following to generate the schema:")
+println(join(prim, " "))
+println(join(tab, " "))
 
 # Generate and display a query to get (names, salaries)
 formula = create(Person)⋅employees #dunit(Person)⋅(employees⊗customers)⋅mmerge(ID)
+
+println("\n\nCopy this for the query: ")
 println(make_query(Schema(types, rels), formula))

--- a/experiments/Schema/src/Testing.jl
+++ b/experiments/Schema/src/Testing.jl
@@ -11,14 +11,14 @@ F = Ob(FreeBicategoryRelationsMeet, Float64)
 ID = Ob(FreeBicategoryRelationsMeet, (:ID, (id=Int,)))
 
 # Define the relationships
-name = Hom((name=:names, fields=("person", "full_name")), Person, Name)
+names = Hom((name=:names, fields=("person", "full_name")), Person, Name)
 emply = Hom((name=:employees, fields=("person", "ID")), Person, ID)
 manag = Hom((name=:manager, fields=("person", "manager")), Person, Person)
 salry = Hom((name=:salary, fields=("person", "salary")), Person, F)
 
 # Set up arrays of types and relationships for Schema
 types = [Name, Person, X,F,ID]
-rels = [name, emply, manag, salry]
+rels = [names, emply, manag, salry]
 
 # Generate the Schema
 prim, tab = sql(Schema(types, rels))
@@ -26,7 +26,5 @@ prim, tab = sql(Schema(types, rels))
 @show tab
 
 # Generate and display a query to get (names, salaries)
-println(make_query(Schema(types, rels), meet(dagger(emply)⋅name, dagger(emply)⋅dagger(manag)⋅name)))
-
-# get the salary of a person's manager
-# query(manag⋅salry) == "select (manager.id, salary.salary) from manager join salary on manager.manager == salary.id"
+formula = dagger(names)⋅salry
+println(make_query(Schema(types, rels), formula))


### PR DESCRIPTION
This PR is made to illustrate the differences between using Types as Tables in SQL as a Bicategory and Types as Types. The Types as Tables implementation allows all Bicategorical functions to be directly implemented, but does require additional machinery to work.